### PR TITLE
DM-22817: Annual refresh of conda env

### DIFF
--- a/etc/conda3_bleed-linux-64.yml
+++ b/etc/conda3_bleed-linux-64.yml
@@ -11,6 +11,7 @@ dependencies:
   - bottleneck
   - cffi
   - cython
+  - deprecated
   - future
   - h5py
   - matplotlib
@@ -32,5 +33,4 @@ dependencies:
   - scipy
   - sqlalchemy
   - pip:
-    - deprecated
     - pytest-subtests

--- a/etc/conda3_bleed-linux-64.yml
+++ b/etc/conda3_bleed-linux-64.yml
@@ -7,12 +7,14 @@ channels:
   - defaults
 dependencies:
   - astropy
+  - boto3
   - bottleneck
   - cffi
   - cython
   - future
   - h5py
   - matplotlib
+  - moto
   - nomkl
   - numexpr
   - numpy
@@ -31,3 +33,4 @@ dependencies:
   - sqlalchemy
   - pip:
     - deprecated
+    - pytest-subtests

--- a/etc/conda3_bleed-osx-64.yml
+++ b/etc/conda3_bleed-osx-64.yml
@@ -11,6 +11,7 @@ dependencies:
   - bottleneck
   - cffi
   - cython
+  - deprecated
   - future
   - h5py
   - matplotlib
@@ -31,5 +32,4 @@ dependencies:
   - scipy
   - sqlalchemy
   - pip:
-    - deprecated
     - pytest-subtests

--- a/etc/conda3_bleed-osx-64.yml
+++ b/etc/conda3_bleed-osx-64.yml
@@ -7,12 +7,14 @@ channels:
   - defaults
 dependencies:
   - astropy
+  - boto3
   - bottleneck
   - cffi
   - cython
   - future
   - h5py
   - matplotlib
+  - moto
   - numexpr
   - numpy
   - pandas
@@ -30,3 +32,4 @@ dependencies:
   - sqlalchemy
   - pip:
     - deprecated
+    - pytest-subtests

--- a/etc/conda3_packages-linux-64.yml
+++ b/etc/conda3_packages-linux-64.yml
@@ -140,7 +140,7 @@ dependencies:
   - snappy=1.1.7=hbae5bb6_3
   - sortedcontainers=2.1.0=py37_0
   - sqlalchemy=1.3.13=py37h7b6447c_0
-  - sqlite=3.31.1=h7b6447c_0
+  - sqlite=3.30.1=h7b6447c_0
   - thrift-cpp=0.11.0=h02b749d_3
   - tk=8.6.8=hbc83047_0
   - tornado=6.0.3=py37h7b6447c_3

--- a/etc/conda3_packages-linux-64.yml
+++ b/etc/conda3_packages-linux-64.yml
@@ -1,118 +1,163 @@
-name: pinned_20191030
+name: pinned_20200205
 channels:
   - defaults
-  - conda-forge
 dependencies:
   - _libgcc_mutex=0.1=main
   - apipkg=1.5=py37_0
-  - arrow-cpp=0.13.0=py37h117bdfb_0
-  - asn1crypto=0.24.0=py37_0
-  - astropy=3.2.3=py37h516909a_0
-  - atomicwrites=1.3.0=py_0
-  - attrs=19.1.0=py_0
+  - appdirs=1.4.3=py37h28b3542_0
+  - arrow-cpp=0.15.1=py37h248a92f_5
+  - asn1crypto=1.3.0=py37_0
+  - astropy=4.0=py37h7b6447c_0
+  - attrs=19.3.0=py_0
+  - aws-xray-sdk=2.4.2=py37_0
+  - backports=1.0=py_2
+  - backports.tempfile=1.0=py_1
+  - backports.weakref=1.0.post1=py_1
   - blas=1.0=openblas
-  - blosc=1.15.0=hd408876_0
-  - boost-cpp=1.67.0=h14c3975_4
-  - bottleneck=1.2.1=py37h035aef0_1
+  - blosc=1.16.3=hd408876_0
+  - boost-cpp=1.71.0=h7b6447c_0
+  - boto=2.49.0=py37_0
+  - boto3=1.11.0=py_0
+  - botocore=1.14.0=py_0
+  - bottleneck=1.3.1=py37hdd07704_0
   - brotli=1.0.7=he6710b0_0
-  - bzip2=1.0.6=h14c3975_5
-  - ca-certificates=2019.1.23=0
-  - certifi=2019.3.9=py37_0
-  - cffi=1.12.2=py37h2e261b9_1
-  - chardet=3.0.4=py37_1
-  - coverage=4.5.4=py37h7b6447c_0
-  - cryptography=2.6.1=py37h1ba5d50_0
+  - bzip2=1.0.8=h7b6447c_0
+  - c-ares=1.15.0=h7b6447c_1001
+  - ca-certificates=2020.1.1=0
+  - certifi=2019.11.28=py37_0
+  - cffi=1.13.2=py37h2e261b9_0
+  - chardet=3.0.4=py37_1003
+  - click=7.0=py37_0
+  - cookies=2.2.1=py37_1
+  - coverage=5.0=py37h7b6447c_0
+  - cryptography=2.8=py37h1ba5d50_0
   - cycler=0.10.0=py37_0
-  - cython=0.29.6=py37he6710b0_0
-  - dbus=1.13.6=h746ee38_0
+  - cython=0.29.14=py37he6710b0_0
+  - dbus=1.13.12=h746ee38_0
+  - dicttoxml=1.7.4=py37_1
+  - docker-py=4.0.2=py37_0
+  - docker-pycreds=0.4.0=py_0
+  - docutils=0.15.2=py37_0
   - double-conversion=3.1.5=he6710b0_1
+  - ecdsa=0.13=py37_1
   - execnet=1.7.1=py_0
   - expat=2.2.6=he6710b0_0
+  - flask=1.1.1=py_0
   - fontconfig=2.13.0=h9420a91_0
   - freetype=2.9.1=h8a8886c_1
-  - future=0.17.1=py37_0
+  - future=0.18.2=py37_0
   - gflags=2.2.2=he6710b0_0
-  - glib=2.56.2=hd408876_0
+  - glib=2.63.1=h5a9c865_0
   - glog=0.4.0=he6710b0_0
+  - gmp=6.1.2=h6c8ec71_1
+  - grpc-cpp=1.26.0=hf8bcb03_0
   - gst-plugins-base=1.14.0=hbbd80ab_1
   - gstreamer=1.14.0=hb453b48_1
-  - h5py=2.9.0=py37h7918eee_0
+  - h5py=2.10.0=py37h7918eee_0
   - hdf5=1.10.4=hb1b8bf9_0
+  - hypothesis=5.4.1=py_0
   - icu=58.2=h9c2bf20_1
   - idna=2.8=py37_0
+  - importlib_metadata=1.5.0=py37_0
+  - inflect=4.1.0=py37_0
+  - itsdangerous=1.1.0=py37_0
+  - jaraco.itertools=5.0.0=py_0
+  - jinja2=2.11.1=py_0
+  - jmespath=0.9.4=py_0
+  - joblib=0.14.1=py_0
   - jpeg=9b=h024ee3a_2
-  - kiwisolver=1.0.1=py37hf484d3e_0
-  - libboost=1.67.0=h46d08c1_4
+  - jsondiff=1.1.1=py37_0
+  - jsonpickle=1.2=py_0
+  - kiwisolver=1.1.0=py37he6710b0_0
+  - ld_impl_linux-64=2.33.1=h53a641e_7
+  - libboost=1.71.0=h97c9712_0
   - libedit=3.1.20181209=hc058e9b_0
   - libevent=2.1.8=h1ba5d50_0
   - libffi=3.2.1=hd88cf55_4
-  - libgcc-ng=8.2.0=hdf63c60_1
+  - libgcc-ng=9.1.0=hdf63c60_0
   - libgfortran-ng=7.3.0=hdf63c60_0
-  - libopenblas=0.3.3=h5a2b251_3
-  - libpng=1.6.36=hbc83047_0
-  - libprotobuf=3.6.0=hdbcaa40_0
-  - libstdcxx-ng=8.2.0=hdf63c60_1
+  - libopenblas=0.3.6=h5a2b251_2
+  - libpng=1.6.37=hbc83047_0
+  - libprotobuf=3.11.2=hd408876_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
   - libuuid=1.0.3=h1bed415_2
   - libxcb=1.13=h1bed415_1
-  - libxml2=2.9.9=he19cac6_0
+  - libxml2=2.9.9=hea5a465_1
   - lz4-c=1.8.1.2=h14c3975_0
   - lzo=2.10=h49e0be7_2
+  - markupsafe=1.1.1=py37h7b6447c_0
   - matplotlib=3.0.3=py37h5429711_0
-  - more-itertools=6.0.0=py37_0
+  - mock=3.0.5=py37_0
+  - more-itertools=8.2.0=py_0
+  - moto=1.3.7=py_0
   - ncurses=6.1=he6710b0_1
   - nomkl=3.0=0
-  - numexpr=2.6.9=py37h2ffa06c_0
-  - numpy=1.16.2=py37h99e49ec_0
-  - numpy-base=1.16.2=py37h2f8d375_0
-  - openssl=1.1.1b=h7b6447c_1
-  - pandas=0.24.2=py37he6710b0_0
+  - numexpr=2.7.1=py37h7ea95a0_0
+  - numpy=1.18.1=py37h94c655d_0
+  - numpy-base=1.18.1=py37h2f8d375_1
+  - openssl=1.1.1d=h7b6447c_3
+  - packaging=20.1=py_0
+  - pandas=1.0.0=py37h0573a6f_0
   - pcre=8.43=he6710b0_0
-  - pip=19.0.3=py37_0
-  - pluggy=0.9.0=py37_0
-  - psutil=5.6.1=py37h7b6447c_0
-  - py=1.8.0=py37_0
-  - pyarrow=0.13.0=py37he6710b0_0
+  - pip=20.0.2=py37_1
+  - pluggy=0.13.1=py37_0
+  - psutil=5.6.7=py37h7b6447c_0
+  - py=1.8.1=py_0
+  - pyaml=19.4.1=py_0
+  - pyarrow=0.15.1=py37h962f231_0
   - pycparser=2.19=py37_0
-  - pyopenssl=19.0.0=py37_0
-  - pyparsing=2.3.1=py37_0
+  - pycryptodome=3.8.2=py37hb69a4c5_0
+  - pyopenssl=19.1.0=py37_0
+  - pyparsing=2.4.6=py_0
   - pyqt=5.9.2=py37h05f1152_2
-  - pysocks=1.6.8=py37_0
-  - pytables=3.5.1=py37h71ec239_0
-  - pytest=4.5.0=py37_0
+  - pysocks=1.7.1=py37_0
+  - pytables=3.6.1=py37h71ec239_0
+  - pytest=5.3.5=py37_0
   - pytest-arraydiff=0.3=py37h39e3cac_0
-  - pytest-astropy=0.5.0=py37_0
-  - pytest-cov=2.7.1=py_0
-  - pytest-doctestplus=0.3.0=py37_0
-  - pytest-forked=1.0.2=py37_0
-  - pytest-openfiles=0.3.2=py37_0
-  - pytest-remotedata=0.3.1=py37_0
-  - pytest-xdist=1.29.0=py_0
-  - python=3.7.2=h0371630_0
-  - python-dateutil=2.8.0=py37_0
-  - pytz=2018.9=py37_0
-  - pyyaml=5.1=py37h7b6447c_0
+  - pytest-astropy=0.7.0=py_0
+  - pytest-astropy-header=0.1.2=py_0
+  - pytest-cov=2.8.1=py_0
+  - pytest-doctestplus=0.5.0=py_0
+  - pytest-forked=1.1.3=py_0
+  - pytest-openfiles=0.4.0=py_0
+  - pytest-remotedata=0.3.2=py37_0
+  - pytest-xdist=1.30.0=py_0
+  - python=3.7.6=h0371630_2
+  - python-dateutil=2.8.1=py_0
+  - python-jose=2.0.2=py37_0
+  - pytz=2019.3=py_0
+  - pyyaml=5.3=py37h7b6447c_0
   - qt=5.9.7=h5867ecd_1
   - re2=2019.08.01=he6710b0_0
   - readline=7.0=h7b6447c_5
-  - requests=2.21.0=py37_0
-  - scikit-learn=0.20.3=py37h22eb022_0
-  - scipy=1.2.1=py37he2b7bc3_0
-  - setuptools=40.8.0=py37_0
+  - requests=2.22.0=py37_1
+  - responses=0.10.8=py37_0
+  - s3transfer=0.3.0=py37_0
+  - scikit-learn=0.22.1=py37h22eb022_0
+  - scipy=1.4.1=py37habc2bb6_0
+  - setuptools=45.1.0=py37_0
   - sip=4.19.8=py37hf484d3e_0
-  - six=1.12.0=py37_0
+  - six=1.14.0=py37_0
   - snappy=1.1.7=hbae5bb6_3
-  - sqlalchemy=1.3.1=py37h7b6447c_0
-  - sqlite=3.27.2=h7b6447c_0
+  - sortedcontainers=2.1.0=py37_0
+  - sqlalchemy=1.3.13=py37h7b6447c_0
+  - sqlite=3.31.1=h7b6447c_0
   - thrift-cpp=0.11.0=h02b749d_3
   - tk=8.6.8=hbc83047_0
-  - tornado=6.0.1=py37h7b6447c_0
-  - urllib3=1.24.1=py37_0
-  - wcwidth=0.1.7=py37_0
-  - wheel=0.33.1=py37_0
-  - wrapt=1.11.1=py37h7b6447c_0
+  - tornado=6.0.3=py37h7b6447c_0
+  - uriparser=0.9.3=he6710b0_1
+  - urllib3=1.25.8=py37_0
+  - wcwidth=0.1.8=py_0
+  - websocket-client=0.56.0=py37_0
+  - werkzeug=0.16.1=py_0
+  - wheel=0.34.2=py37_0
+  - wrapt=1.11.2=py37h7b6447c_0
+  - xmltodict=0.12.0=py_0
   - xz=5.2.4=h14c3975_4
   - yaml=0.1.7=had09818_2
+  - zipp=2.1.0=py_0
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
   - pip:
-    - deprecated==1.2.5
+    - deprecated==1.2.7
+    - pytest-subtests==0.3.0

--- a/etc/conda3_packages-linux-64.yml
+++ b/etc/conda3_packages-linux-64.yml
@@ -1,4 +1,4 @@
-name: pinned_20200205
+name: pinned_20200211
 channels:
   - defaults
 dependencies:
@@ -25,14 +25,14 @@ dependencies:
   - c-ares=1.15.0=h7b6447c_1001
   - ca-certificates=2020.1.1=0
   - certifi=2019.11.28=py37_0
-  - cffi=1.13.2=py37h2e261b9_0
+  - cffi=1.14.0=py37h2e261b9_0
   - chardet=3.0.4=py37_1003
   - click=7.0=py37_0
   - cookies=2.2.1=py37_1
   - coverage=5.0=py37h7b6447c_0
   - cryptography=2.8=py37h1ba5d50_0
   - cycler=0.10.0=py37_0
-  - cython=0.29.14=py37he6710b0_0
+  - cython=0.29.15=py37he6710b0_0
   - dbus=1.13.12=h746ee38_0
   - deprecated=1.2.6=py_0
   - dicttoxml=1.7.4=py37_1
@@ -60,9 +60,7 @@ dependencies:
   - icu=58.2=h9c2bf20_1
   - idna=2.8=py37_0
   - importlib_metadata=1.5.0=py37_0
-  - inflect=4.1.0=py37_0
   - itsdangerous=1.1.0=py37_0
-  - jaraco.itertools=5.0.0=py_0
   - jinja2=2.11.1=py_0
   - jmespath=0.9.4=py_0
   - joblib=0.14.1=py_0
@@ -88,7 +86,7 @@ dependencies:
   - lzo=2.10=h49e0be7_2
   - markupsafe=1.1.1=py37h7b6447c_0
   - matplotlib=3.0.3=py37h5429711_0
-  - mock=3.0.5=py37_0
+  - mock=4.0.1=py_0
   - more-itertools=8.2.0=py_0
   - moto=1.3.7=py_0
   - ncurses=6.1=he6710b0_1
@@ -96,9 +94,9 @@ dependencies:
   - numexpr=2.7.1=py37h7ea95a0_0
   - numpy=1.18.1=py37h94c655d_0
   - numpy-base=1.18.1=py37h2f8d375_1
-  - openssl=1.1.1d=h7b6447c_3
+  - openssl=1.1.1d=h7b6447c_4
   - packaging=20.1=py_0
-  - pandas=1.0.0=py37h0573a6f_0
+  - pandas=1.0.1=py37h0573a6f_0
   - pcre=8.43=he6710b0_0
   - pip=20.0.2=py37_1
   - pluggy=0.13.1=py37_0
@@ -136,7 +134,7 @@ dependencies:
   - s3transfer=0.3.0=py37_0
   - scikit-learn=0.22.1=py37h22eb022_0
   - scipy=1.4.1=py37habc2bb6_0
-  - setuptools=45.1.0=py37_0
+  - setuptools=45.2.0=py37_0
   - sip=4.19.8=py37hf484d3e_0
   - six=1.14.0=py37_0
   - snappy=1.1.7=hbae5bb6_3
@@ -145,18 +143,18 @@ dependencies:
   - sqlite=3.31.1=h7b6447c_0
   - thrift-cpp=0.11.0=h02b749d_3
   - tk=8.6.8=hbc83047_0
-  - tornado=6.0.3=py37h7b6447c_0
+  - tornado=6.0.3=py37h7b6447c_3
   - uriparser=0.9.3=he6710b0_1
   - urllib3=1.25.8=py37_0
   - wcwidth=0.1.8=py_0
   - websocket-client=0.56.0=py37_0
-  - werkzeug=0.16.1=py_0
+  - werkzeug=1.0.0=py_0
   - wheel=0.34.2=py37_0
   - wrapt=1.11.2=py37h7b6447c_0
   - xmltodict=0.12.0=py_0
   - xz=5.2.4=h14c3975_4
   - yaml=0.1.7=had09818_2
-  - zipp=2.1.0=py_0
+  - zipp=2.2.0=py_0
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
   - pip:

--- a/etc/conda3_packages-linux-64.yml
+++ b/etc/conda3_packages-linux-64.yml
@@ -34,6 +34,7 @@ dependencies:
   - cycler=0.10.0=py37_0
   - cython=0.29.14=py37he6710b0_0
   - dbus=1.13.12=h746ee38_0
+  - deprecated=1.2.6=py_0
   - dicttoxml=1.7.4=py37_1
   - docker-py=4.0.2=py37_0
   - docker-pycreds=0.4.0=py_0
@@ -159,5 +160,4 @@ dependencies:
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
   - pip:
-    - deprecated==1.2.7
     - pytest-subtests==0.3.0

--- a/etc/conda3_packages-osx-64.yml
+++ b/etc/conda3_packages-osx-64.yml
@@ -1,40 +1,67 @@
-name: pinned_20191030
+name: pinned_20200205
 channels:
   - defaults
-  - conda-forge
 dependencies:
   - apipkg=1.5=py37_0
-  - arrow-cpp=0.13.0=py37h8cfbac2_0
-  - asn1crypto=0.24.0=py37_0
-  - astropy=3.2.3=py37h0b31af3_0
-  - atomicwrites=1.3.0=py_0
-  - attrs=19.1.0=py_0
+  - appdirs=1.4.3=py37h28b3542_0
+  - arrow-cpp=0.15.1=py37h3051d0f_5
+  - asn1crypto=1.3.0=py37_0
+  - astropy=4.0=py37h1de35cc_0
+  - attrs=19.3.0=py_0
+  - aws-xray-sdk=2.4.2=py37_0
+  - backports=1.0=py_2
+  - backports.tempfile=1.0=py_1
+  - backports.weakref=1.0.post1=py_1
   - blas=1.0=mkl
-  - blosc=1.15.0=hd9629dc_0
+  - blosc=1.16.3=hd9629dc_0
   - boost-cpp=1.67.0=h1de35cc_4
-  - bottleneck=1.2.1=py37h1d22016_1
+  - boto=2.49.0=py37_0
+  - boto3=1.11.0=py_0
+  - botocore=1.14.0=py_0
+  - bottleneck=1.3.1=py37h1d22016_0
   - brotli=1.0.7=h0a44026_0
-  - bzip2=1.0.6=h1de35cc_5
-  - ca-certificates=2019.1.23=0
-  - certifi=2019.3.9=py37_0
-  - cffi=1.12.2=py37hb5b8e2f_1
-  - chardet=3.0.4=py37_1
-  - coverage=4.5.4=py37h1de35cc_0
-  - cryptography=2.6.1=py37ha12b0ac_0
+  - bzip2=1.0.8=h1de35cc_0
+  - c-ares=1.15.0=h1de35cc_1001
+  - ca-certificates=2020.1.1=0
+  - certifi=2019.11.28=py37_0
+  - cffi=1.13.2=py37hb5b8e2f_0
+  - chardet=3.0.4=py37_1003
+  - click=7.0=py37_0
+  - cookies=2.2.1=py37_1
+  - coverage=5.0=py37h1de35cc_0
+  - cryptography=2.8=py37ha12b0ac_0
   - cycler=0.10.0=py37_0
-  - cython=0.29.6=py37h0a44026_0
+  - cython=0.29.14=py37h0a44026_0
+  - dicttoxml=1.7.4=py37_1
+  - docker-py=4.0.2=py37_0
+  - docker-pycreds=0.4.0=py_0
+  - docutils=0.15.2=py37_0
   - double-conversion=3.1.5=haf313ee_1
+  - ecdsa=0.13=py37_1
   - execnet=1.7.1=py_0
+  - flask=1.1.1=py_0
   - freetype=2.9.1=hb4e5f40_0
-  - future=0.17.1=py37_0
+  - future=0.18.2=py37_0
   - gflags=2.2.2=h0a44026_0
   - glog=0.4.0=h0a44026_0
-  - h5py=2.9.0=py37h3134771_0
+  - gmp=6.1.2=hb37e062_1
+  - grpc-cpp=1.26.0=h044775b_0
+  - h5py=2.10.0=py37h3134771_0
   - hdf5=1.10.4=hfa1e0ec_0
+  - hypothesis=5.4.1=py_0
   - icu=58.2=h4b95b61_1
   - idna=2.8=py37_0
-  - intel-openmp=2019.1=144
-  - kiwisolver=1.0.1=py37h0a44026_0
+  - importlib_metadata=1.5.0=py37_0
+  - inflect=4.1.0=py37_0
+  - intel-openmp=2020.0=166
+  - itsdangerous=1.1.0=py37_0
+  - jaraco.itertools=5.0.0=py_0
+  - jinja2=2.11.1=py_0
+  - jmespath=0.9.4=py_0
+  - joblib=0.14.1=py_0
+  - jsondiff=1.1.1=py37_0
+  - jsonpickle=1.2=py_0
+  - kiwisolver=1.1.0=py37h0a44026_0
   - libboost=1.67.0=hebc422b_4
   - libcxx=4.0.1=hcfea43d_1
   - libcxxabi=4.0.1=hcfea43d_1
@@ -43,64 +70,83 @@ dependencies:
   - libffi=3.2.1=h475c297_4
   - libgfortran=3.0.1=h93005f0_2
   - libiconv=1.15=hdd342a3_7
-  - libpng=1.6.36=ha441bb4_0
-  - libprotobuf=3.6.0=hd9629dc_0
+  - libpng=1.6.37=ha441bb4_0
+  - libprotobuf=3.11.2=hd9629dc_0
+  - llvm-openmp=4.0.1=hcfea43d_1
   - lz4-c=1.8.1.2=h1de35cc_0
   - lzo=2.10=h362108e_2
+  - markupsafe=1.1.1=py37h1de35cc_0
   - matplotlib=3.0.3=py37h54f8f79_0
-  - mkl=2019.1=144
-  - mkl_fft=1.0.10=py37h5e564d8_0
-  - mkl_random=1.0.2=py37h27c97d8_0
-  - more-itertools=6.0.0=py37_0
+  - mkl=2020.0=166
+  - mkl-service=2.3.0=py37hfbe908c_0
+  - mkl_fft=1.0.15=py37h5e564d8_0
+  - mkl_random=1.1.0=py37ha771720_0
+  - mock=3.0.5=py37_0
+  - more-itertools=8.2.0=py_0
+  - moto=1.3.7=py_0
   - ncurses=6.1=h0a44026_1
-  - numexpr=2.6.9=py37h7413580_0
-  - numpy=1.16.2=py37hacdab7b_0
-  - numpy-base=1.16.2=py37h6575580_0
-  - openssl=1.1.1b=h1de35cc_1
-  - pandas=0.24.2=py37h0a44026_0
-  - pip=19.0.3=py37_0
-  - pluggy=0.9.0=py37_0
-  - psutil=5.6.1=py37h1de35cc_0
-  - py=1.8.0=py37_0
-  - pyarrow=0.13.0=py37h0a44026_0
+  - numexpr=2.7.1=py37hce01a72_0
+  - numpy=1.18.1=py37h7241aed_0
+  - numpy-base=1.18.1=py37h6575580_1
+  - openssl=1.1.1d=h1de35cc_3
+  - packaging=20.1=py_0
+  - pandas=1.0.0=py37h6c726b0_0
+  - pip=20.0.2=py37_1
+  - pluggy=0.13.1=py37_0
+  - psutil=5.6.7=py37h1de35cc_0
+  - py=1.8.1=py_0
+  - pyaml=19.4.1=py_0
+  - pyarrow=0.15.1=py37h6440ff4_0
   - pycparser=2.19=py37_0
-  - pyopenssl=19.0.0=py37_0
-  - pyparsing=2.3.1=py37_0
-  - pysocks=1.6.8=py37_0
-  - pytables=3.5.1=py37h5bccee9_0
-  - pytest=4.5.0=py37_0
+  - pycryptodome=3.8.2=py37ha8bbb54_0
+  - pyopenssl=19.1.0=py37_0
+  - pyparsing=2.4.6=py_0
+  - pysocks=1.7.1=py37_0
+  - pytables=3.6.1=py37h5bccee9_0
+  - pytest=5.3.5=py37_0
   - pytest-arraydiff=0.3=py37h39e3cac_0
-  - pytest-astropy=0.5.0=py37_0
-  - pytest-cov=2.7.1=py_0
-  - pytest-doctestplus=0.3.0=py37_0
-  - pytest-forked=1.0.2=py37_0
-  - pytest-openfiles=0.3.2=py37_0
-  - pytest-remotedata=0.3.1=py37_0
-  - pytest-xdist=1.29.0=py_0
-  - python=3.7.2=haf84260_0
-  - python-dateutil=2.8.0=py37_0
-  - pytz=2018.9=py37_0
-  - pyyaml=5.1=py37h1de35cc_0
+  - pytest-astropy=0.7.0=py_0
+  - pytest-astropy-header=0.1.2=py_0
+  - pytest-cov=2.8.1=py_0
+  - pytest-doctestplus=0.5.0=py_0
+  - pytest-forked=1.1.3=py_0
+  - pytest-openfiles=0.4.0=py_0
+  - pytest-remotedata=0.3.2=py37_0
+  - pytest-xdist=1.30.0=py_0
+  - python=3.7.6=h359304d_2
+  - python-dateutil=2.8.1=py_0
+  - python-jose=2.0.2=py37_0
+  - pytz=2019.3=py_0
+  - pyyaml=5.3=py37h1de35cc_0
   - re2=2019.08.01=h0a44026_0
   - readline=7.0=h1de35cc_5
-  - requests=2.21.0=py37_0
-  - scikit-learn=0.20.3=py37h27c97d8_0
-  - scipy=1.2.1=py37h1410ff5_0
-  - setuptools=40.8.0=py37_0
-  - six=1.12.0=py37_0
+  - requests=2.22.0=py37_1
+  - responses=0.10.8=py37_0
+  - s3transfer=0.3.0=py37_0
+  - scikit-learn=0.22.1=py37h27c97d8_0
+  - scipy=1.4.1=py37h9fa6033_0
+  - setuptools=45.1.0=py37_0
+  - six=1.14.0=py37_0
   - snappy=1.1.7=he62c110_3
-  - sqlalchemy=1.3.1=py37h1de35cc_0
-  - sqlite=3.27.2=ha441bb4_0
+  - sortedcontainers=2.1.0=py37_0
+  - sqlalchemy=1.3.13=py37h1de35cc_0
+  - sqlite=3.31.1=ha441bb4_0
   - thrift-cpp=0.11.0=hd79cdb6_3
   - tk=8.6.8=ha441bb4_0
-  - tornado=6.0.1=py37h1de35cc_0
-  - urllib3=1.24.1=py37_0
-  - wcwidth=0.1.7=py37_0
-  - wheel=0.33.1=py37_0
-  - wrapt=1.11.1=py37h1de35cc_0
+  - tornado=6.0.3=py37h1de35cc_0
+  - uriparser=0.9.3=h0a44026_1
+  - urllib3=1.25.8=py37_0
+  - wcwidth=0.1.8=py_0
+  - websocket-client=0.56.0=py37_0
+  - werkzeug=0.16.1=py_0
+  - wheel=0.34.2=py37_0
+  - wrapt=1.11.2=py37h1de35cc_0
+  - xmltodict=0.12.0=py_0
   - xz=5.2.4=h1de35cc_4
   - yaml=0.1.7=hc338f04_2
+  - zipp=2.1.0=py_0
   - zlib=1.2.11=h1de35cc_3
   - zstd=1.3.7=h5bba6e5_0
   - pip:
-    - deprecated==1.2.5
+    - deprecated==1.2.7
+    - pytest-subtests==0.3.0

--- a/etc/conda3_packages-osx-64.yml
+++ b/etc/conda3_packages-osx-64.yml
@@ -1,4 +1,4 @@
-name: pinned_20200205
+name: pinned_20200211
 channels:
   - defaults
 dependencies:
@@ -24,14 +24,14 @@ dependencies:
   - c-ares=1.15.0=h1de35cc_1001
   - ca-certificates=2020.1.1=0
   - certifi=2019.11.28=py37_0
-  - cffi=1.13.2=py37hb5b8e2f_0
+  - cffi=1.14.0=py37hb5b8e2f_0
   - chardet=3.0.4=py37_1003
   - click=7.0=py37_0
   - cookies=2.2.1=py37_1
   - coverage=5.0=py37h1de35cc_0
   - cryptography=2.8=py37ha12b0ac_0
   - cycler=0.10.0=py37_0
-  - cython=0.29.14=py37h0a44026_0
+  - cython=0.29.15=py37h0a44026_0
   - deprecated=1.2.6=py_0
   - dicttoxml=1.7.4=py37_1
   - docker-py=4.0.2=py37_0
@@ -53,10 +53,8 @@ dependencies:
   - icu=58.2=h4b95b61_1
   - idna=2.8=py37_0
   - importlib_metadata=1.5.0=py37_0
-  - inflect=4.1.0=py37_0
   - intel-openmp=2020.0=166
   - itsdangerous=1.1.0=py37_0
-  - jaraco.itertools=5.0.0=py_0
   - jinja2=2.11.1=py_0
   - jmespath=0.9.4=py_0
   - joblib=0.14.1=py_0
@@ -78,20 +76,20 @@ dependencies:
   - lzo=2.10=h362108e_2
   - markupsafe=1.1.1=py37h1de35cc_0
   - matplotlib=3.0.3=py37h54f8f79_0
-  - mkl=2020.0=166
+  - mkl=2019.4=233
   - mkl-service=2.3.0=py37hfbe908c_0
   - mkl_fft=1.0.15=py37h5e564d8_0
   - mkl_random=1.1.0=py37ha771720_0
-  - mock=3.0.5=py37_0
+  - mock=4.0.1=py_0
   - more-itertools=8.2.0=py_0
   - moto=1.3.7=py_0
   - ncurses=6.1=h0a44026_1
   - numexpr=2.7.1=py37hce01a72_0
   - numpy=1.18.1=py37h7241aed_0
   - numpy-base=1.18.1=py37h6575580_1
-  - openssl=1.1.1d=h1de35cc_3
+  - openssl=1.1.1d=h1de35cc_4
   - packaging=20.1=py_0
-  - pandas=1.0.0=py37h6c726b0_0
+  - pandas=1.0.1=py37h6c726b0_0
   - pip=20.0.2=py37_1
   - pluggy=0.13.1=py37_0
   - psutil=5.6.7=py37h1de35cc_0
@@ -126,7 +124,7 @@ dependencies:
   - s3transfer=0.3.0=py37_0
   - scikit-learn=0.22.1=py37h27c97d8_0
   - scipy=1.4.1=py37h9fa6033_0
-  - setuptools=45.1.0=py37_0
+  - setuptools=45.2.0=py37_0
   - six=1.14.0=py37_0
   - snappy=1.1.7=he62c110_3
   - sortedcontainers=2.1.0=py37_0
@@ -134,18 +132,18 @@ dependencies:
   - sqlite=3.31.1=ha441bb4_0
   - thrift-cpp=0.11.0=hd79cdb6_3
   - tk=8.6.8=ha441bb4_0
-  - tornado=6.0.3=py37h1de35cc_0
+  - tornado=6.0.3=py37h1de35cc_3
   - uriparser=0.9.3=h0a44026_1
   - urllib3=1.25.8=py37_0
   - wcwidth=0.1.8=py_0
   - websocket-client=0.56.0=py37_0
-  - werkzeug=0.16.1=py_0
+  - werkzeug=1.0.0=py_0
   - wheel=0.34.2=py37_0
   - wrapt=1.11.2=py37h1de35cc_0
   - xmltodict=0.12.0=py_0
   - xz=5.2.4=h1de35cc_4
   - yaml=0.1.7=hc338f04_2
-  - zipp=2.1.0=py_0
+  - zipp=2.2.0=py_0
   - zlib=1.2.11=h1de35cc_3
   - zstd=1.3.7=h5bba6e5_0
   - pip:

--- a/etc/conda3_packages-osx-64.yml
+++ b/etc/conda3_packages-osx-64.yml
@@ -32,6 +32,7 @@ dependencies:
   - cryptography=2.8=py37ha12b0ac_0
   - cycler=0.10.0=py37_0
   - cython=0.29.14=py37h0a44026_0
+  - deprecated=1.2.6=py_0
   - dicttoxml=1.7.4=py37_1
   - docker-py=4.0.2=py37_0
   - docker-pycreds=0.4.0=py_0
@@ -148,5 +149,4 @@ dependencies:
   - zlib=1.2.11=h1de35cc_3
   - zstd=1.3.7=h5bba6e5_0
   - pip:
-    - deprecated==1.2.7
     - pytest-subtests==0.3.0

--- a/etc/conda3_packages-osx-64.yml
+++ b/etc/conda3_packages-osx-64.yml
@@ -129,7 +129,7 @@ dependencies:
   - snappy=1.1.7=he62c110_3
   - sortedcontainers=2.1.0=py37_0
   - sqlalchemy=1.3.13=py37h1de35cc_0
-  - sqlite=3.31.1=ha441bb4_0
+  - sqlite=3.30.1-ha441bb4_0
   - thrift-cpp=0.11.0=hd79cdb6_3
   - tk=8.6.8=ha441bb4_0
   - tornado=6.0.3=py37h1de35cc_3


### PR DESCRIPTION
* Version refresh
* Adds boto3 and moto conda packages
* Move deprecated from pip to conda
* Add pip pytest-subtests

Not entirely sure how pyarrow fits in here since it's pulling in the v0.15 conda (not conda-forge) version. @yalsayyad any thoughts?