### PR TITLE
DM-22817: Rebuild conda env for macOS mkl problem

### DIFF
--- a/etc/conda3_packages-linux-64.yml
+++ b/etc/conda3_packages-linux-64.yml
@@ -1,4 +1,4 @@
-name: pinned_20200211
+name: pinned_20200217
 channels:
   - defaults
 dependencies:
@@ -17,8 +17,8 @@ dependencies:
   - blosc=1.16.3=hd408876_0
   - boost-cpp=1.71.0=h7b6447c_0
   - boto=2.49.0=py37_0
-  - boto3=1.11.0=py_0
-  - botocore=1.14.0=py_0
+  - boto3=1.12.0=py_0
+  - botocore=1.15.0=py_0
   - bottleneck=1.3.1=py37hdd07704_0
   - brotli=1.0.7=he6710b0_0
   - bzip2=1.0.8=h7b6447c_0
@@ -113,14 +113,14 @@ dependencies:
   - pytables=3.6.1=py37h71ec239_0
   - pytest=5.3.5=py37_0
   - pytest-arraydiff=0.3=py37h39e3cac_0
-  - pytest-astropy=0.7.0=py_0
+  - pytest-astropy=0.8.0=py_0
   - pytest-astropy-header=0.1.2=py_0
   - pytest-cov=2.8.1=py_0
   - pytest-doctestplus=0.5.0=py_0
   - pytest-forked=1.1.3=py_0
   - pytest-openfiles=0.4.0=py_0
   - pytest-remotedata=0.3.2=py37_0
-  - pytest-xdist=1.30.0=py_0
+  - pytest-xdist=1.31.0=py_0
   - python=3.7.6=h0371630_2
   - python-dateutil=2.8.1=py_0
   - python-jose=2.0.2=py37_0
@@ -131,7 +131,7 @@ dependencies:
   - readline=7.0=h7b6447c_5
   - requests=2.22.0=py37_1
   - responses=0.10.8=py37_0
-  - s3transfer=0.3.0=py37_0
+  - s3transfer=0.3.3=py37_0
   - scikit-learn=0.22.1=py37h22eb022_0
   - scipy=1.4.1=py37habc2bb6_0
   - setuptools=45.2.0=py37_0

--- a/etc/conda3_packages-osx-64.yml
+++ b/etc/conda3_packages-osx-64.yml
@@ -1,4 +1,4 @@
-name: pinned_20200211
+name: pinned_20200217
 channels:
   - defaults
 dependencies:
@@ -16,8 +16,8 @@ dependencies:
   - blosc=1.16.3=hd9629dc_0
   - boost-cpp=1.67.0=h1de35cc_4
   - boto=2.49.0=py37_0
-  - boto3=1.11.0=py_0
-  - botocore=1.14.0=py_0
+  - boto3=1.12.0=py_0
+  - botocore=1.15.0=py_0
   - bottleneck=1.3.1=py37h1d22016_0
   - brotli=1.0.7=h0a44026_0
   - bzip2=1.0.8=h1de35cc_0
@@ -53,7 +53,7 @@ dependencies:
   - icu=58.2=h4b95b61_1
   - idna=2.8=py37_0
   - importlib_metadata=1.5.0=py37_0
-  - intel-openmp=2020.0=166
+  - intel-openmp=2019.4=233
   - itsdangerous=1.1.0=py37_0
   - jinja2=2.11.1=py_0
   - jmespath=0.9.4=py_0
@@ -104,14 +104,14 @@ dependencies:
   - pytables=3.6.1=py37h5bccee9_0
   - pytest=5.3.5=py37_0
   - pytest-arraydiff=0.3=py37h39e3cac_0
-  - pytest-astropy=0.7.0=py_0
+  - pytest-astropy=0.8.0=py_0
   - pytest-astropy-header=0.1.2=py_0
   - pytest-cov=2.8.1=py_0
   - pytest-doctestplus=0.5.0=py_0
   - pytest-forked=1.1.3=py_0
   - pytest-openfiles=0.4.0=py_0
   - pytest-remotedata=0.3.2=py37_0
-  - pytest-xdist=1.30.0=py_0
+  - pytest-xdist=1.31.0=py_0
   - python=3.7.6=h359304d_2
   - python-dateutil=2.8.1=py_0
   - python-jose=2.0.2=py37_0
@@ -121,7 +121,7 @@ dependencies:
   - readline=7.0=h1de35cc_5
   - requests=2.22.0=py37_1
   - responses=0.10.8=py37_0
-  - s3transfer=0.3.0=py37_0
+  - s3transfer=0.3.3=py37_0
   - scikit-learn=0.22.1=py37h27c97d8_0
   - scipy=1.4.1=py37h9fa6033_0
   - setuptools=45.2.0=py37_0


### PR DESCRIPTION
There were some problems with mkl mismatch on macOS which only
appeared after valid tests.