### PR TITLE
Pin mpich version.

### DIFF
--- a/etc/conda3_bleed-linux-64.yml
+++ b/etc/conda3_bleed-linux-64.yml
@@ -49,7 +49,7 @@ dependencies:
   - matplotlib
   - minuit2
   - moto
-  - mpich
+  - mpich =3.2.1
   - mpi4py
   - ndarray
   - numexpr

--- a/etc/conda3_bleed-osx-64.yml
+++ b/etc/conda3_bleed-osx-64.yml
@@ -48,7 +48,7 @@ dependencies:
   - matplotlib
   - minuit2
   - moto
-  - mpich
+  - mpich =3.2.1
   - mpi4py
   - ndarray
   - numexpr


### PR DESCRIPTION
3.3 versions do not properly handle hostnames like `lsst-verify-worker14`.